### PR TITLE
'dzil cover --open' opens the coverage reports in a browser

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+    - add --open option
+    - add --cover_args option
     - fixed POD
 
 1.101000  2010-04-10 15:15:25 Europe/Vienna

--- a/lib/Dist/Zilla/App/Command/cover.pm
+++ b/lib/Dist/Zilla/App/Command/cover.pm
@@ -9,12 +9,17 @@ use Dist::Zilla::App -command;
 use File::Temp;
 use Path::Class;
 use File::chdir;
+use Browser::Open qw( open_browser );
 sub abstract { "code coverage metrics for your distribution" }
 
+sub opt_spec {
+    [ 'open' => 'open the coverage results in a browser' ],
+}
+
 sub execute {
-    my $self = shift;
+    my ($self, $opt, $arg) = @_;
     local $ENV{HARNESS_PERL_SWITCHES} = '-MDevel::Cover';
-    my @cover_command = @ARGV;
+    my @cover_command = ('cover', @$arg);
 
     # adapted from the 'test' command
     my $zilla = $self->zilla;
@@ -30,10 +35,15 @@ sub execute {
     $zilla->ensure_built_in($target);
     $self->zilla->run_tests_in($target);
 
+
     $self->log(join ' ' => @cover_command);
     local $CWD = $target;
     system @cover_command;
     $self->log("leaving $target intact");
+
+    if ($opt->open) {
+        open_browser("cover_db/coverage.html", 1);
+    }
 }
 1;
 


### PR DESCRIPTION
Hi Mike,

Here's a patch which adds a `--open` option to automatically open the coverage reports in a browser (using Browser::Open).

The first commit just add the `--open` option. The remaining arguments are passed through to `cover` as before.

Simply plucking `--open` from the options feels a bit clunky to me, so the second commit adds a `--cover_args` option which takes over the `cover` arguments.

Cheers,
Steve
