### PR TITLE
Change SYNOPSIS cover flags to -launch

### DIFF
--- a/lib/Dist/Zilla/App/Command/cover.pm
+++ b/lib/Dist/Zilla/App/Command/cover.pm
@@ -9,7 +9,7 @@ use Dist::Zilla::App -command;
 
 =head1 SYNOPSIS
 
-    # dzil cover -outputdir /my/dir
+    # dzil cover -launch
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
This is a follow-up to issue #1.

The --open option from that patch now exists as a -launch option in Devel::Cover itself.

I use `devel cover -launch` all the time, and I imagine others might find it useful, so I thought this synopsis patch might be appropriate.

(My assumption is that the previous -outputdir flag was really just an illustration of how to pass flags through to the cover command, so I've removed that one - apologies if that's not the case)

The -launch option requires Devel::Cover >= 0.88 and Browser::Open
